### PR TITLE
Fix deoplete auto complete

### DIFF
--- a/ftplugin/gdscript3.vim
+++ b/ftplugin/gdscript3.vim
@@ -53,16 +53,18 @@ fun! <SID>Set(name, default)
 endfun
 
 " Deoplete
-call <SID>Set("g:deoplete#sources", "{}")
-call <SID>Set("g:deoplete#omni#input_patterns", "{}")
-let g:deoplete#sources.gdscript3 = ["omni"]
-let g:deoplete#omni#input_patterns.gdscript3 = [
-    \ '\.|\w+',
-    \ '\bextends\s+',
-    \ '\bexport\(',
-    \ '\bfunc\s+',
-    \ '"res://[^"]*'
+call deoplete#custom#option('sources', {
+    \ 'gdscript3': ['omni'],
+\ })
+call deoplete#custom#var('omni', 'input_patterns', {
+    \ 'gdscript3': [
+        \ '\.|\w+',
+        \ '\bextends\s+',
+        \ '\bexport\(',
+        \ '\bfunc\s+',
+        \ '"res://[^"]*'
     \ ]
+\ })
 
 " SuperTab
 let g:SuperTabDefaultCompletionType = "<c-x><c-o>"


### PR DESCRIPTION
These days I went back to using Godot and found it strange that auto complete does not work.
In the search, I discovered that some "time" ago Shougo removed a lot of [variables][1], `input_patterns` and `sources` included.

Seeing that updating the configuration of Deoplete fixed the problem, I decided to make this Pull Request to help those who are having problems with the auto complete.

[1]: https://github.com/Shougo/deoplete.nvim/blob/master/doc/deoplete.txt#L1663