### PR TITLE
Static typing

### DIFF
--- a/python/completer.py
+++ b/python/completer.py
@@ -118,10 +118,7 @@ def complete_dot():
             if builtin_class:
                 _add_class_items(builtin_class, flags)
             else:
-                c_decl = script.find_decl_down(0, c_name, script.CLASS_DECLS)
-                flags = script.ANY_DECLS ^ script.CLASS_DECLS
-                for member in script.iter_decls(c_decl.line, 1, flags):
-                    append_completion(build_completion(member))
+                _add_user_class_items(c_name, flags)
 
 # Complete user declared items in the script and items from the extended class.
 # If 'include_globals' is True, add items from global scope.
@@ -145,6 +142,20 @@ def complete_script(include_globals):
     if include_globals:
         complete_class_names(classes.EXTENDABLE)
         _add_class_items(classes.get_global_scope())
+
+# Recursively add class items for user defined classes.
+def _add_user_class_items(c_name, flags):
+    if not flags:
+        flags = script.ANY_DECLS ^ script.CLASS_DECLS
+    while c_name:
+        c_decl = script.find_decl_down(0, c_name, script.CLASS_DECLS)
+        for member in script.iter_decls(c_decl.line, 1, flags):
+            append_completion(build_completion(member))
+        c_name = c_decl.extends
+        builtin_class = classes.get_class(c_name)
+        if builtin_class:
+            _add_class_items(builtin_class, flags)
+            break
 
 # Recursively add class items.
 def _add_class_items(c, flags=None):

--- a/python/completer.py
+++ b/python/completer.py
@@ -206,12 +206,16 @@ def build_completion(item, c_name=None):
             d["word"] = item.name
             if item.value:
                 d["abbr"] = "{} = {}".format(item.name, item.value)
+            if item.type:
+                d["kind"] = item.type
         elif t is script.FuncDecl:
             if len(item.args) > 0:
                 d["word"] = "{}(".format(item.name)
             else:
                 d["word"] = "{}()".format(item.name)
             d["abbr"] = "{}({})".format(item.name, ", ".join(item.args))
+            if item.returns:
+                d["kind"] = item.returns
         elif t is script.EnumDecl:
             d["word"] = item.name
             d["kind"] = "enum"

--- a/python/completer.py
+++ b/python/completer.py
@@ -186,7 +186,7 @@ def build_completion(item, c_name=None):
                 d["word"] = "{}(".format(item.name)
             else:
                 d["word"] = "{}()".format(item.name)
-            args = list(map(lambda a: "{} {}".format(a.type, a.name), item.args))
+            args = list(map(lambda a: "{}: {}".format(a.name, a.type), item.args))
             qualifiers = " {}".format(item.qualifiers) if item.qualifiers else ""
             if "vararg" in qualifiers:
                 args.append("...")

--- a/python/completer.py
+++ b/python/completer.py
@@ -114,7 +114,14 @@ def complete_dot():
         elif last_token_type is script.VariableToken:
             c_name = last_token.type
         if c_name:
-            _add_class_items(classes.get_class(c_name), flags)
+            builtin_class = classes.get_class(c_name)
+            if builtin_class:
+                _add_class_items(builtin_class, flags)
+            else:
+                c_decl = script.find_decl_down(0, c_name, script.CLASS_DECLS)
+                flags = script.ANY_DECLS ^ script.CLASS_DECLS
+                for member in script.iter_decls(c_decl.line, 1, flags):
+                    append_completion(build_completion(member))
 
 # Complete user declared items in the script and items from the extended class.
 # If 'include_globals' is True, add items from global scope.

--- a/python/script.py
+++ b/python/script.py
@@ -350,13 +350,15 @@ def get_token_chain(line, line_num, start_col):
     elif not chain or chain[-1].name == "self":
         if not chain and name == "self":
             return [VariableToken(name, None)]
-        decl = find_decl(line_num, name, ENUM_DECLS | CLASS_DECLS)
+        decl = find_decl(line_num, name, ENUM_DECLS | CLASS_DECLS | VAR_DECLS)
         if decl:
             decl_type = type(decl)
             if decl_type is EnumDecl:
                 return [EnumToken(name, decl.line)]
             elif decl_type is ClassDecl:
                 return [ClassToken(name, decl.line)]
+            elif decl_type is VarDecl:
+                return [VariableToken(name, decl.type)]
         else:
             extended_class = classes.get_class(get_extended_class(line_num))
             if extended_class:

--- a/python/script.py
+++ b/python/script.py
@@ -61,7 +61,7 @@ def _get_decl(lnum, flags):
             args = m.group(3)
             returns = m.group(4)
             if args:
-                args = [" ".join(a.split()) for a in args.split(",")]
+                args = ["".join(a.split()).replace(":",": ") for a in args.split(",")]
             return FuncDecl(lnum, static, name, args, returns)
 
     if flags & ENUM_DECLS:


### PR DESCRIPTION
This patch updates the regex patterns for variable, constant and
function definitions to include the optional static typing feature that
was introduced with Godot 3.1. Parsed type information is stored, but
completion of user declarations has yet to be implemented.