### PR TITLE
fixing tab size

### DIFF
--- a/ftplugin/gdscript3.vim
+++ b/ftplugin/gdscript3.vim
@@ -1,3 +1,5 @@
+setloacl shiftwidth=4 " set tabs size to fit godot default scripts
+setloacl softtabstop=4
 setlocal commentstring=#\ %s
 
 if exists("g:gdscript3_loaded")


### PR DESCRIPTION
the original plugin takes the default vim tab size, it might be better to fix it to the right size since godot scripts should respect a certain spacing